### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export * as path from "https://deno.land/std@0.110.0/path/mod.ts";
-export * as fs from "https://deno.land/std@0.110.0/fs/mod.ts";
+export * as path from "https://deno.land/std@0.111.0/path/mod.ts";
+export * as fs from "https://deno.land/std@0.111.0/fs/mod.ts";
 
 export type { Disposable } from "https://deno.land/x/disposable@v1.0.2/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.110.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.111.0/testing/asserts.ts";
 export { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts";


### PR DESCRIPTION
The output of `make update` is

```
./deps_test.ts
[1/2] Looking for releases: https://deno.land/std@0.110.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.111.0
[1/2] Update successful: https://deno.land/std@0.110.0/testing/asserts.ts -> 0.111.0
[2/2] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts
[2/2] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts

./mod.ts

./deps.ts
[1/3] Looking for releases: https://deno.land/std@0.110.0/path/mod.ts
[1/3] Attempting update: https://deno.land/std@0.110.0/path/mod.ts -> 0.111.0
[1/3] Update successful: https://deno.land/std@0.110.0/path/mod.ts -> 0.111.0
[2/3] Looking for releases: https://deno.land/std@0.110.0/fs/mod.ts
[2/3] Attempting update: https://deno.land/std@0.110.0/fs/mod.ts -> 0.111.0
[2/3] Update successful: https://deno.land/std@0.110.0/fs/mod.ts -> 0.111.0
[3/3] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts
[3/3] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts

./sandbox.ts

./sandbox_test.ts

Already latest version:
https://deno.land/x/disposable@v1.0.2/mod.ts == v1.0.2
https://deno.land/x/disposable@v1.0.2/mod.ts == v1.0.2

Successfully updated:
https://deno.land/std@0.110.0/testing/asserts.ts 0.110.0 -> 0.111.0
https://deno.land/std@0.110.0/path/mod.ts 0.110.0 -> 0.111.0
https://deno.land/std@0.110.0/fs/mod.ts 0.110.0 -> 0.111.0
make[1]: Entering directory '/home/runner/work/deno-sandbox/deno-sandbox'
make[1]: Leaving directory '/home/runner/work/deno-sandbox/deno-sandbox'

```