### PR TITLE
feat: support multiple path arguments in Sandbox.resolve

### DIFF
--- a/sandbox.ts
+++ b/sandbox.ts
@@ -6,9 +6,22 @@ export type Sandbox = {
    */
   readonly path: string;
   /**
-   * Resolve a path relative to the sandbox directory
+   * Resolve path segments relative to the sandbox directory.
+   * Works like `@std/path/resolve`, joining all path segments from left to right.
+   *
+   * @param pathSegments - Path segments to resolve
+   * @returns The resolved absolute path within the sandbox
+   *
+   * @example
+   * ```ts
+   * import { sandbox } from "@lambdalisue/sandbox";
+   *
+   * await using sbox = await sandbox();
+   * sbox.resolve("foo", "bar", "baz.txt");
+   * // => "/tmp/sandbox-xxx/foo/bar/baz.txt"
+   * ```
    */
-  resolve(path: string): string;
+  resolve(...pathSegments: string[]): string;
 };
 
 /**
@@ -79,8 +92,8 @@ export async function sandbox(): Promise<Sandbox & AsyncDisposable> {
   const path = await Deno.realPath(await Deno.makeTempDir());
   return {
     path,
-    resolve: (relativePath: string) => {
-      return resolve(path, relativePath);
+    resolve: (...pathSegments: string[]) => {
+      return resolve(path, ...pathSegments);
     },
     [Symbol.asyncDispose]: async () => {
       try {
@@ -160,8 +173,8 @@ export function sandboxSync(): Sandbox & Disposable {
   const path = Deno.realPathSync(Deno.makeTempDirSync());
   return {
     path,
-    resolve: (relativePath: string) => {
-      return resolve(path, relativePath);
+    resolve: (...pathSegments: string[]) => {
+      return resolve(path, ...pathSegments);
     },
     [Symbol.dispose]: () => {
       try {

--- a/sandbox_test.ts
+++ b/sandbox_test.ts
@@ -276,3 +276,25 @@ Deno.test({
     assertEquals(content, "Hello");
   },
 });
+
+Deno.test({
+  name: "Sandbox.resolve() supports multiple path arguments",
+  fn: async () => {
+    await using sbox = await sandbox();
+    await Deno.mkdir(sbox.resolve("foo"));
+    await Deno.mkdir(sbox.resolve("foo", "bar"));
+    await using _f = await Deno.create(sbox.resolve("foo", "bar", "baz.txt"));
+    assertExists(sbox.resolve("foo", "bar", "baz.txt"));
+  },
+});
+
+Deno.test({
+  name: "SandboxSync.resolve() supports multiple path arguments",
+  fn: () => {
+    using sbox = sandboxSync();
+    Deno.mkdirSync(sbox.resolve("foo"));
+    Deno.mkdirSync(sbox.resolve("foo", "bar"));
+    using _f = Deno.createSync(sbox.resolve("foo", "bar", "baz.txt"));
+    assertExists(sbox.resolve("foo", "bar", "baz.txt"));
+  },
+});


### PR DESCRIPTION
## Summary
- Allow `Sandbox.resolve()` to accept multiple path segments like `@std/path/resolve`
- Enables convenient path construction: `sbox.resolve("foo", "bar", "baz.txt")`
- Maintains backward compatibility with single-argument usage

## Changes
- Updated `Sandbox` type definition to accept variadic parameters `(...pathSegments: string[])`
- Modified `sandbox()` and `sandboxSync()` implementations to spread arguments to `@std/path/resolve`
- Added comprehensive tests for both async and sync versions
- Updated JSDoc with example usage and detailed documentation

## Test plan
- [x] All existing tests pass (28 tests)
- [x] New tests added for multi-argument resolution
- [x] `deno fmt` passes
- [x] `deno lint` passes
- [x] Backward compatibility verified (single-argument usage still works)

## Example usage
```typescript
import { sandbox } from "@lambdalisue/sandbox";

await using sbox = await sandbox();

// Single argument (existing behavior)
sbox.resolve("foo");

// Multiple arguments (new feature)
sbox.resolve("foo", "bar", "baz.txt");
// => "/tmp/sandbox-xxx/foo/bar/baz.txt"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The path resolution functionality now supports multiple path segments as variadic arguments, enabling more convenient and flexible path construction.

* **Tests**
  * Added tests validating that path resolution correctly handles multiple path segments in both synchronous and asynchronous operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->